### PR TITLE
update: モバイル環境のUIの改善 refs #1

### DIFF
--- a/pages/comps/[id].vue
+++ b/pages/comps/[id].vue
@@ -38,14 +38,17 @@
                 {{ formatTimestamp(item.updated_at) }}
               </td>
               <td data-label="Result Image">
-                <div v-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
-                  <v-btn density="comfortable" variant="text" color="blue" @click="openPreviewDialog(item.image_url)">Click to preview</v-btn>
-                </div>
-                <div v-else-if="isTrustedSite(item.image_url)">
-                  <NuxtLink :to="item.image_url" target="_blank">{{ getHostnameFromURL(item.image_url) }}</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
-                </div>
+                <div v-if="isPortraitMobile"><span class="font-weight-light text-grey-lighten-1" style="font-size: 0.7em;">モバイル環境では閲覧できません</span></div>
                 <div v-else>
-                  {{ item.image_url }}
+                  <div v-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
+                    <v-btn density="comfortable" variant="text" color="blue" @click="openPreviewDialog(item.image_url)">Click to preview</v-btn>
+                  </div>
+                  <div v-else-if="isTrustedSite(item.image_url)">
+                    <NuxtLink :to="item.image_url" target="_blank">{{ getHostnameFromURL(item.image_url) }}</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
+                  </div>
+                  <div v-else>
+                    {{ item.image_url }}
+                  </div>
                 </div>
               </td>
               <td data-label="Comment">{{ item.comment }}</td>
@@ -125,6 +128,9 @@ const deleteDialog = ref(false)
 const previewImageDialog = ref(false)
 const previewImageUrl = ref("")
 
+const isPortraitMobile = ref(false)
+const mediaQuery = window.matchMedia('(max-width: 600px)');
+
 const submissionPageUrl = `/submit/${route.params.id}`
 
 async function getCompInfo() {
@@ -188,10 +194,22 @@ function openPreviewDialog(image_url) {
   previewImageDialog.value = true
 }
 
+function onChangeScreenSize(query) {
+  if (query.matches) {
+    isPortraitMobile.value = true
+  } else {
+    isPortraitMobile.value = false
+  }
+}
+
 onMounted(() => {
   getCompInfo()
   getScoreInfo()
   setLoggedIn()
+
+  onChangeScreenSize(mediaQuery)
+  mediaQuery.addEventListener('change', onChangeScreenSize)
+
   isLoading.value = false
 })
 </script>

--- a/pages/comps/[id].vue
+++ b/pages/comps/[id].vue
@@ -38,14 +38,11 @@
                 {{ formatTimestamp(item.updated_at) }}
               </td>
               <td data-label="Result Image">
-                <div v-if="getHostnameFromURL(item.image_url) === 'twitter.com' || getHostnameFromURL(item.image_url) === 'x.com'">
-                  <NuxtLink :to="item.image_url" target="_blank"><v-icon color="blue" :icon="SvgTwitter" size="x-small" class="mr-1"></v-icon>Twitter</NuxtLink>
-                </div>
-                <div v-else-if="getHostnameFromURL(item.image_url) === 'imgur.com'">
-                  <NuxtLink :to="item.image_url" target="_blank">imgur.com</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
-                </div>
-                <div v-else-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
+                <div v-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
                   <v-btn density="comfortable" variant="text" color="blue" @click="openPreviewDialog(item.image_url)">Click to preview</v-btn>
+                </div>
+                <div v-else-if="isTrustedSite(item.image_url)">
+                  <NuxtLink :to="item.image_url" target="_blank">{{ getHostnameFromURL(item.image_url) }}</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
                 </div>
                 <div v-else>
                   {{ item.image_url }}

--- a/pages/comps/[id].vue
+++ b/pages/comps/[id].vue
@@ -22,32 +22,37 @@
 
       <div class="text-left">
         <v-data-table :items="scoreInfo" :headers="headers" item-key="user_uid" v-model:sort-by="sortBy" multi-sort :loading="scoreLoading">
-          <template v-slot:item.rank="{ item }">
-            <div class="text-center">
-              <div v-if="item.rank == 1"><v-icon icon="mdi-crown" color="amber"></v-icon></div>
-              <div v-else-if="item.rank <= 3" class="font-weight-bold">{{ item.rank }}</div>
-              <div v-else>{{ item.rank }}</div>
-            </div>
-          </template>
-          <template v-slot:item.user_uid="{ item }">
-            {{ item.users.nickname }}
-          </template>
-          <template v-slot:item.updated_at="{ item }">
-            {{ formatTimestamp(item.updated_at) }}
-          </template>
-          <template v-slot:item.image_url="{ item }">
-            <div v-if="getHostnameFromURL(item.image_url) === 'twitter.com' || getHostnameFromURL(item.image_url) === 'x.com'">
-              <NuxtLink :to="item.image_url" target="_blank"><v-icon color="blue" :icon="SvgTwitter" size="x-small" class="mr-1"></v-icon>Twitter</NuxtLink>
-            </div>
-            <div v-else-if="getHostnameFromURL(item.image_url) === 'imgur.com'">
-              <NuxtLink :to="item.image_url" target="_blank">imgur.com</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
-            </div>
-            <div v-else-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
-              <v-btn density="comfortable" variant="text" color="blue" @click="openPreviewDialog(item.image_url)">Click to preview</v-btn>
-            </div>
-            <div v-else>
-              {{ item.image_url }}
-            </div>
+          <template v-slot:item="{ item }">
+            <tr>
+              <td data-label="Rank">
+                <div class="text-center">
+                  <div v-if="item.rank == 1"><v-icon icon="mdi-crown" color="amber"></v-icon></div>
+                  <div v-else-if="item.rank == 2"><v-icon icon="mdi-crown" color="blue-grey-lighten-2"></v-icon></div>
+                  <div v-else-if="item.rank == 3"><v-icon icon="mdi-crown" color="brown"></v-icon></div>
+                  <div v-else>{{ item.rank }}</div>
+                </div>
+              </td>
+              <td data-label="Player Name">{{ item.users.nickname }}</td>
+              <td data-label="Score">{{ item.score }}</td>
+              <td data-label="Updated at">
+                {{ formatTimestamp(item.updated_at) }}
+              </td>
+              <td data-label="Result Image">
+                <div v-if="getHostnameFromURL(item.image_url) === 'twitter.com' || getHostnameFromURL(item.image_url) === 'x.com'">
+                  <NuxtLink :to="item.image_url" target="_blank"><v-icon color="blue" :icon="SvgTwitter" size="x-small" class="mr-1"></v-icon>Twitter</NuxtLink>
+                </div>
+                <div v-else-if="getHostnameFromURL(item.image_url) === 'imgur.com'">
+                  <NuxtLink :to="item.image_url" target="_blank">imgur.com</NuxtLink><span class="text-caption text-blue-grey-lighten-1">（外部リンク）</span>
+                </div>
+                <div v-else-if="getHostnameFromURL(item.image_url) === 'irpics.mgcup.net'">
+                  <v-btn density="comfortable" variant="text" color="blue" @click="openPreviewDialog(item.image_url)">Click to preview</v-btn>
+                </div>
+                <div v-else>
+                  {{ item.image_url }}
+                </div>
+              </td>
+              <td data-label="Comment">{{ item.comment }}</td>
+            </tr>
           </template>
           <template v-slot:loading>
             <v-skeleton-loader type="table-row@1"></v-skeleton-loader>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,13 +24,20 @@
     </div>
     <div>
       <v-data-table :items="comps" :headers="headers" item-key="name" v-model:sort-by="sortBy" :loading="tableLoading">
-        <template v-slot:item.name="{ item }">
-          <NuxtLink :to="'comps/' + item.id">{{ item.name }}</NuxtLink>
-        </template>
-        <template v-slot:item.open_until="{ item }">
-          <div :class="{'text-grey-lighten-1': !isCompOpen(item.open_until)}">
-            {{ formatTimestamp(item.open_until) }}
-          </div>
+        <template v-slot:item="{ item }">
+          <tr>
+            <td data-label="Name">
+              <NuxtLink :to="'comps/' + item.id">{{ item.name }}</NuxtLink>
+            </td>
+            <td data-label="Game Title">{{ item.game_title }}</td>
+            <td data-label="Song Title">{{ item.song_title }}</td>
+            <td data-label="Difficulty">{{ item.difficulty }}</td>
+            <td data-label="Open Until">
+              <div :class="{'text-grey-lighten-1': !isCompOpen(item.open_until)}">
+                {{ formatTimestamp(item.open_until) }}
+              </div>
+            </td>
+          </tr>
         </template>
         <template v-slot:loading>
           <v-skeleton-loader type="table-row@1"></v-skeleton-loader>

--- a/utils/isTrustedSite.ts
+++ b/utils/isTrustedSite.ts
@@ -1,0 +1,14 @@
+export default function (url: string): boolean {
+  const hostname = getHostnameFromURL(url);
+  if (!hostname) {
+    return false;
+  }
+
+  const trusted = [
+    'twitter.com',
+    'x.com',
+    'imgur.com'
+  ]
+
+  return trusted.includes(hostname);
+}


### PR DESCRIPTION
# 変更要素
- `v-data-table`の`<td>`に対して`data-label`属性を追加し、ヘッダーがモバイル環境で表示されなかったバグを修正
- リザルト画像のカラムの影響でモバイル環境で各大会ページのテーブルが正しく描画されていなかったため、モバイル環境専用の分岐を追加して対応