### PR TITLE
feat: 開催予定の大会の表示に対応など

### DIFF
--- a/middleware/canSubmit.ts
+++ b/middleware/canSubmit.ts
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js'
+
+export default defineNuxtRouteMiddleware(async (to, from) => {
+  const runtimeConfig = useRuntimeConfig()
+  const supabase = createClient('https://zczqyrsjbntkitypaaww.supabase.co', runtimeConfig.public.anonKey)
+
+  const isCompExists = async () => {
+    const compId = to.params.id
+    const { data, error } = await supabase
+      .from('tournaments')
+      .select('id')
+      .eq('id', compId)
+    
+    if (!data || data.length == 0) {
+      return false
+    }
+    return true
+  }
+
+  /** 大会が現在開催されているかどうか検証する */
+  const isCompActive = async () => {
+    const compId = to.params.id
+    const { data, error } = await supabase
+      .from('tournaments')
+      .select('open_since,open_until')
+      .eq('id', compId)
+      .limit(1)
+      .single()
+    
+    if (error || !data) {
+      return false
+    }
+
+    return isCompOpen(data.open_since, data.open_until)
+  } 
+
+  if (!await isCompExists()) {
+    return abortNavigation()
+  } else if (!await isCompActive()) {
+    return abortNavigation()
+  }
+})

--- a/pages/comps/[id].vue
+++ b/pages/comps/[id].vue
@@ -3,14 +3,18 @@
     <div v-if="!isLoading" class="text-center">
       <div class="text-h3 my-4">{{ compInfo.name }}</div>
       <div class="text-h6 ma-1">{{ compInfo.song_title }} [{{ compInfo.difficulty }}]</div>
-      <div class="text-subtitle-2 ma-1">スコア登録期間: {{ formatTimestamp(compInfo.open_until) }} まで <span v-if="!isCompOpen(compInfo.open_until)">(開催終了)</span></div>
+      <div class="text-subtitle-2 ma-1">
+        スコア登録期間: {{ formatTimestamp(compInfo.open_since) }} - {{ formatTimestamp(compInfo.open_until) }} 
+        <span v-if="isCompClosed(compInfo.open_until)">(開催終了)</span>
+        <span v-else-if="isCompUpcoming(compInfo.open_since)">(開催予定)</span>
+      </div>
 
       <div class="text-body-1 ma-4" style="white-space: pre-wrap;">{{ compInfo.desc }}</div>
 
-      <div v-if="(isLoggedIn && isCompOpen(compInfo.open_until)) || canDelete" class="my-4">
+      <div v-if="(isLoggedIn && isCompOpen(compInfo.open_since, compInfo.open_until)) || canDelete" class="my-4">
         <div style="max-width: 500px;" class="mx-auto">
           <v-row>
-            <v-col v-if="isCompOpen(compInfo.open_until)">
+            <v-col v-if="isCompOpen(compInfo.open_since, compInfo.open_until)">
               <v-btn size="large" :to="submissionPageUrl" color="blue" prepend-icon="mdi-pencil-box">スコア提出</v-btn>
             </v-col>
             <v-col v-if="canDelete">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,14 +30,18 @@
       <v-card flat>
         <v-tabs v-model="tab" align-tabs="center" color="deep-purple-accent-3">
           <v-tab value="open">開催中</v-tab>
+          <v-tab value="upcoming">開催予定</v-tab>
           <v-tab value="closed">終了済み</v-tab>
         </v-tabs>
         <v-window v-model="tab">
           <v-window-item value="open">
             <CompTable table-title="開催中の大会" />
           </v-window-item>
+          <v-window-item value="upcoming">
+            <CompTable type="upcoming" table-title="開催予定の大会" />
+          </v-window-item>
           <v-window-item value="closed">
-            <CompTable show-closed table-title="終了済みの大会" />
+            <CompTable type="closed" table-title="終了済みの大会" />
           </v-window-item>
         </v-window>
       </v-card>

--- a/pages/submit/[id].vue
+++ b/pages/submit/[id].vue
@@ -3,7 +3,9 @@
     <div v-if="!isLoading && compInfo != null" class="text-center">
       <div class="text-h3 my-4">{{ compInfo.name }}</div>
       <div class="text-h6 ma-1">{{ compInfo.song_title }} [{{ compInfo.difficulty }}]</div>
-      <div class="text-subtitle-2 ma-1">スコア登録期間: {{ formatTimestamp(compInfo.open_until) }} まで</div>
+      <div class="text-subtitle-2 ma-1">
+        スコア登録期間: {{ formatTimestamp(compInfo.open_since) }} - {{ formatTimestamp(compInfo.open_until) }}
+      </div>
 
       <div>
         <v-alert
@@ -275,7 +277,7 @@ async function getCompInfo() {
   const { data } = await supabase.from('tournaments').select('*').eq('id', route.params.id).limit(1).single()
   compInfo.value = data
 
-  if (!isCompOpen(data.open_until)) {
+  if (!isCompOpen(data.open_since, data.open_until)) {
     compNotOpen.value = true
   }
 
@@ -462,7 +464,7 @@ watch(imageFiles, (newFiles) => {
 })
 
 definePageMeta({
-  middleware: ['auth'],
+  middleware: ['auth', 'can-submit'],
 })
 
 type Comp = {
@@ -476,5 +478,8 @@ type Comp = {
   open_until: string
   passwd: string
   created_by: string
+  asc_order: boolean
+  score_visible: boolean
+  open_since: string
 }
 </script>

--- a/utils/formatTimestamp.ts
+++ b/utils/formatTimestamp.ts
@@ -1,3 +1,10 @@
 export default function (timestamp: string) {
-  return new Date(timestamp).toLocaleString()
+  const padZero = function (num: number) {
+    return num.toString().padStart(2, '0')
+  }
+
+  const d = new Date(timestamp)
+
+  // 日付をyyyy/mm/dd hh:mm形式に整形する
+  return `${d.getFullYear()}/${padZero(d.getMonth() + 1)}/${padZero(d.getDate())} ${padZero(d.getHours())}:${padZero(d.getMinutes())}`
 }

--- a/utils/isCompClosed.ts
+++ b/utils/isCompClosed.ts
@@ -1,0 +1,4 @@
+/** 大会の終了日時が現在時刻よりも前かどうか判定する */
+export default function (endTimestamp: string): boolean {
+  return new Date(endTimestamp) < new Date()
+}

--- a/utils/isCompOpen.ts
+++ b/utils/isCompOpen.ts
@@ -1,4 +1,4 @@
-/** 現在時刻が大会のスコア登録期限より前かどうか検証する */
-export default function (timestamp: string) {
-  return new Date(timestamp) > new Date()
+/** 大会の開催期間に現在時刻が含まれるかどうか判定する */
+export default function (startTimestamp: string, endTimestamp: string): boolean {
+  return new Date(startTimestamp) <= new Date() && new Date(endTimestamp) > new Date()
 }

--- a/utils/isCompUpcoming.ts
+++ b/utils/isCompUpcoming.ts
@@ -1,0 +1,4 @@
+/** 大会の開始日時が現在時刻よりも後かどうか判定する */
+export default function (startTimestamp: string): boolean {
+  return new Date(startTimestamp) > new Date()
+}


### PR DESCRIPTION
# 変更要素
- `open_since`カラムの値によって、大会を開催予定と開催中に区別できるように機能改修
  - 開始日時を指定した大会の作成は未実装