### PR TITLE
feat: 大会の開催開始日時の指定

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -1,3 +1,9 @@
+.v-data-table td {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @media screen and (max-width: 600px) {
 
   .v-data-table thead {

--- a/components/CompTable.vue
+++ b/components/CompTable.vue
@@ -118,12 +118,6 @@ onMounted(() => {
 </script>
 
 <style>
-.v-data-table td {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 @media screen and (min-width: 960px) {
   .comp-table {
     min-width: 780px;

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -12,6 +12,9 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     return true
   }
 
+  // ログインチェックはクライアントで行う必要があるのでスキップ
+  if (import.meta.server) return
+
   if (!await isLoggedIn()) {
     return navigateTo('/login')
   }

--- a/pages/comps/[id].vue
+++ b/pages/comps/[id].vue
@@ -36,7 +36,7 @@
                   <div v-else>{{ item.rank }}</div>
                 </div>
               </td>
-              <td data-label="Player Name">
+              <td class="table-td-player-name" data-label="Player Name">
                 <span :class="{ 'text-pink-accent-2': userInfo && userInfo.id === item.user_uid }">{{ item.users.nickname }}</span>
               </td>
               <td data-label="Score">{{ item.score }}</td>
@@ -57,7 +57,7 @@
                   </div>
                 </div>
               </td>
-              <td data-label="Comment">{{ item.comment }}</td>
+              <td class="table-td-comment" data-label="Comment">{{ item.comment }}</td>
             </tr>
           </template>
           <template v-slot:loading>
@@ -219,3 +219,17 @@ onMounted(() => {
   })
 })
 </script>
+
+<style>
+@media screen and (min-width: 960px) {
+  .table-td-player-name {
+    width: 120px;
+    max-width: 160px;
+  }
+
+  .table-td-comment {
+    width: 250px;
+    max-width: 300px;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,13 +12,13 @@
         <p class="text-body-2" v-if="!isLoggedIn">
           スコア登録のやり方:<br />
           1. <NuxtLink to="/login">ログインページ</NuxtLink>からログインする。<br />
-          2. アカウント情報ページから名前を登録する。<br />
+          2. アカウント設定ページから名前を登録する。<br />
           3. 各大会のページからスコアを登録する。
         </p>
         <p class="text-body-2" v-else>
           スコア登録のやり方:<br />
           1. ログインページからログインする。<br />
-          2. <NuxtLink to="/account">アカウント情報ページ</NuxtLink>から名前を登録する。<br />
+          2. <NuxtLink to="/account">アカウント設定ページ</NuxtLink>から名前を登録する。<br />
           3. 各大会のページからスコアを登録する。
         </p>
       </div>

--- a/utils/validateDateAndTime.ts
+++ b/utils/validateDateAndTime.ts
@@ -1,0 +1,6 @@
+export default function (date: string, time: string): boolean {
+  const timestamp = date + 'T' + time + "+09:00";
+  const d = new Date(timestamp);
+
+  return d.toString() !== 'Invalid Date';
+}


### PR DESCRIPTION
# 追加要素
- 大会作成ページで、大会のスコア登録の開始日時をユーザーが指定できるようにするオプションを追加